### PR TITLE
 set RESET to Pull.UP when set to input

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,8 @@ For breakout boards or other configurations where the boards are separated, it m
 the baudrate for reliable data transmission.
 The baud rate may be specified as an keyword parameter when initializing the board.
 To set it to 1000000 use :
-.. code-block:: python# Initialze RFM radio
+.. code-block:: python
+    # Initialze RFM radio
     rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ,baudrate=1000000)
 
 

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,16 @@ Usage Example
 =============
 
 See examples/simpletest.py for a demo of the usage.
+Note: the default baudrate for the SPI is 10000000 (10MHz). This works well when you are using a board with 
+the radio module built in (FeatherM0 RFM9x) or with an RFM9x FeatherWing mounted directly to a feather board.
+For breakout boards or other configurations where the boards are separated, it may be necessary to reduce
+the baudrate for reliable data transmission.
+The baud rate may be specified as an keyword parameter when initializing the board.
+To set it to 1000000 use :
+.. code-block:: python# Initialze RFM radio
+    rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ,baudrate=1000000)
+
+
 
 Contributing
 ============

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,9 @@ For breakout boards or other configurations where the boards are separated, it m
 the baudrate for reliable data transmission.
 The baud rate may be specified as an keyword parameter when initializing the board.
 To set it to 1000000 use :
+
 .. code-block:: python
+
     # Initialze RFM radio
     rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ,baudrate=1000000)
 

--- a/adafruit_rfm9x.py
+++ b/adafruit_rfm9x.py
@@ -30,7 +30,7 @@ http: www.airspayce.com/mikem/arduino/RadioHead/
 * Author(s): Tony DiCola
 """
 import time
-
+import digitalio
 from micropython import const
 
 import adafruit_bus_device.spi_device as spi_device
@@ -344,7 +344,7 @@ class RFM9x:
         # trigger a reset.  Note that reset MUST be done like this and set as
         # a high impedence input or else the chip cannot change modes (trust me!).
         self._reset = reset
-        self._reset.switch_to_input()
+        self._reset.switch_to_input(pull=digitalio.Pull.UP)
         self.reset()
         # No device type check!  Catch an error from the very first request and
         # throw a nicer message to indicate possible wiring problems.
@@ -421,7 +421,7 @@ class RFM9x:
         # See section 7.2.2 of the datasheet for reset description.
         self._reset.switch_to_output(value=False)
         time.sleep(0.0001)  # 100 us
-        self._reset.switch_to_input()
+        self._reset.switch_to_input(pull=digitalio.Pull.UP)
         time.sleep(0.005)   # 5 ms
 
     def idle(self):


### PR DESCRIPTION
This fixes the generation of the RESET signal to the RFM9x chip for CP3.0  - I'm still not sure why it worked on 2.x but this change works on both 2.x and 3.0.

The reset sequence for the RFM9x is far more complex than the one for the RFM69, but as Tony noted, it works this way.  When I tried the same sequence in the RFM69, it did not work and resulted in a corrupted File System on my feather_m0. So for now, let stick with this ;-)

I tested this with a pair of rfm9x featherwings attached to a feather_m0_express and a feather_m0_supersized (8Mbyte SPI flash) with both CP3.0 master and CP 2.2..4.

I did find  that it works well with the default baudrate setting (10000000) as long as the wing is plugged directly into the feather. I had some transmission errors when I used a "doubler". It has been reported before for the rfm69 that it may be necessary to lower the baud rate for breakout boards  and even apparently for any separation of the boards. 