### PR TITLE
Fix sleep delay for M4 - fix example for RPi

### DIFF
--- a/adafruit_rfm9x.py
+++ b/adafruit_rfm9x.py
@@ -353,11 +353,8 @@ class RFM9x:
             # Set sleep mode, wait 10s and confirm in sleep mode (basic device check).
             # Also set long range mode (LoRa mode) as it can only be done in sleep.
             self.sleep()
-            self.long_range_mode = True
-            #self._write_u8(_RH_RF95_REG_01_OP_MODE, 0b10001000)
             time.sleep(0.01)
-            #val = self._read_u8(_RH_RF95_REG_01_OP_MODE)
-            #print('op mode: {0}'.format(bin(val)))
+            self.long_range_mode = True
             if self.operation_mode != SLEEP_MODE or not self.long_range_mode:
                 raise RuntimeError('Failed to configure radio for LoRa mode, check wiring!')
         except OSError:

--- a/examples/rfm9x_simpletest.py
+++ b/examples/rfm9x_simpletest.py
@@ -36,7 +36,7 @@ rfm9x.tx_power = 23
 # This is a limitation of the radio packet size, so if you need to send larger
 # amounts of data you will need to break it into smaller send calls.  Each send
 # call will wait for the previous one to finish before continuing.
-rfm9x.send('Hello world!\r\n')
+rfm9x.send(bytes("Hello world!\r\n","utf-8"))
 print('Sent hello world message!')
 
 # Wait to receive packets.  Note that this library can't receive data at a fast

--- a/examples/rfm9x_simpletest.py
+++ b/examples/rfm9x_simpletest.py
@@ -37,7 +37,7 @@ rfm9x.tx_power = 23
 # amounts of data you will need to break it into smaller send calls.  Each send
 # call will wait for the previous one to finish before continuing.
 rfm9x.send(bytes("Hello world!\r\n","utf-8"))
-print('Sent hello world message!')
+print('Sent Hello World message!')
 
 # Wait to receive packets.  Note that this library can't receive data at a fast
 # rate, in fact it can only receive and process one 252 byte packet at a time.


### PR DESCRIPTION
The  delay after entering "sleep" mode needed to be moved to immediately after the self.sleep() call. On the M4, the board was not entering sleep mode before the next configuration instructions were being received.
Removed the unnecessary commented out code.

In rfm9x_simpletest.py  -- converted the test message string to a bytesring - this is needed for the Raspberry Pi Python to execute. It also works for CircuitPython.

Tested on:
Feather M4 Express
Feather M0 Express
Raspberry Pi 3B+
