### PR TITLE
GH-18: Fix broken CoC link, added 3.7 to supported list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ To set it to 1000000 use :
 .. code-block:: python
 
     # Initialze RFM radio
-    rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ,baudrate=1000000)
+    rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ, baudrate=1000000)
 
 
 
@@ -48,7 +48,7 @@ Contributing
 ============
 
 Contributions are welcome! Please read our `Code of Conduct
-<https://github.com/adafruit/adafruit_CircuitPython_rfm95/blob/master/CODE_OF_CONDUCT.md>`_
+<https://github.com/adafruit/Adafruit_CircuitPython_RFM9x/blob/master/CODE_OF_CONDUCT.md>`_
 before contributing to help this project stay welcoming.
 
 Building locally

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.7',
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
This is a _very_ minor suggested patch.  I'm breaking out this minor patch from a larger patch which I will offer separately.  In particular, this patch suggests the following:
* make the tiny needed change to the CoC link in the `README.rst`,
* add Python 3.7 to the supported list in the `setup.py` (because I've been using it extensively there with zero problems), and
* add a blank after a comma for consistency in the `README.rst` (perhaps because I am too much of a pedant to not do so).
