### PR TITLE
GH-20: Expose bw, cr, sf controls and CRC checks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,7 @@ This example code matches the wiring used in the
 project:
 
 .. code-block:: python
+
     import digitalio
     import board
     import busio

--- a/README.rst
+++ b/README.rst
@@ -64,15 +64,16 @@ To set it to 1000000 use :
 
 Optional controls exist to alter the signal bandwidth, coding rate, and spreading factor
 settings used by the radio to achieve better performance in different environments.
-By default, settings compatible with RadioHead Bw125Cr45Sf128 mode are used, matching
-the following example:
+By default, settings compatible with RadioHead Bw125Cr45Sf128 mode are used, which can
+be altered in the following manner (continued from the above example):
 
 .. code-block:: python
 
-    # Initialze RFM radio with conservative baudrate and default modem config
-    rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ, baudrate=1000000,
-                                 signal_bandwidth=125000, coding_rate=5, spreading_factor=7,
-                                 enable_crc=False)
+    # Apply new modem config settings to the radio to improve its effective range
+    rfm9x.signal_bandwidth = 62500
+    rfm9x.coding_rate = 6
+    rfm9x.spreading_factor = 8
+    rfm9x.enable_crc = True
 
 See examples/rfm9x_simpletest.py for an expanded demo of the usage.
 

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,26 @@ This is easily achieved by downloading
 Usage Example
 =============
 
-See examples/rfm9x_simpletest.py for a demo of the usage.
+Initialization of the RFM radio requires specifying a frequency appropriate to
+your radio hardware (i.e. 868-915 or 433 MHz) and specifying the pins used in your
+wiring from the controller board to the radio module.
+
+This example code matches the wiring used in the
+`LoRa and LoRaWAN Radio for Raspberry Pi <https://learn.adafruit.com/lora-and-lorawan-radio-for-raspberry-pi/>`_
+project:
+
+.. code-block:: python
+    import digitalio
+    import board
+    import busio
+    import adafruit_rfm9x
+
+    RADIO_FREQ_MHZ = 915.0
+    CS = digitalio.DigitalInOut(board.CE1)
+    RESET = digitalio.DigitalInOut(board.D25)
+    spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
+    rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ)
+
 Note: the default baudrate for the SPI is 50000000 (5MHz). The maximum setting is 10Mhz but 
 transmission errors have been observed expecially when using breakout boards.
 For breakout boards or other configurations where the boards are separated, it may be necessary to reduce
@@ -39,9 +58,21 @@ To set it to 1000000 use :
 
 .. code-block:: python
 
-    # Initialze RFM radio
+    # Initialze RFM radio with a more conservative baudrate
     rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ, baudrate=1000000)
 
+Optional controls exist to alter the signal bandwidth, coding rate, and spreading factor
+settings used by the radio to achieve better performance in different environments.
+By default, settings compatible with RadioHead Bw125Cr45Sf128 mode are used, matching
+the following example:
+
+.. code-block:: python
+
+    # Initialze RFM radio with conservative baudrate and default modem config
+    rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ, baudrate=1000000,
+                                 signal_bandwidth=125000, coding_rate=5, spreading_factor=7)
+
+See examples/rfm9x_simpletest.py for an expanded demo of the usage.
 
 
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ To set it to 1000000 use :
 .. code-block:: python
 
     # Initialze RFM radio
-    rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ,baudrate=1000000)
+    rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ, baudrate=1000000)
 
 
 
@@ -48,7 +48,7 @@ Contributing
 ============
 
 Contributions are welcome! Please read our `Code of Conduct
-<https://github.com/adafruit/adafruit_CircuitPython_rfm95/blob/master/CODE_OF_CONDUCT.md>`_
+<https://github.com/adafruit/Adafruit_CircuitPython_RFM9x/blob/master/CODE_OF_CONDUCT.md>`_
 before contributing to help this project stay welcoming.
 
 Building locally

--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,8 @@ the following example:
 
     # Initialze RFM radio with conservative baudrate and default modem config
     rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ, baudrate=1000000,
-                                 signal_bandwidth=125000, coding_rate=5, spreading_factor=7)
+                                 signal_bandwidth=125000, coding_rate=5, spreading_factor=7,
+                                 enable_crc=False)
 
 See examples/rfm9x_simpletest.py for an expanded demo of the usage.
 

--- a/adafruit_rfm9x.py
+++ b/adafruit_rfm9x.py
@@ -37,7 +37,7 @@ try:
     from warnings import warn
 except ImportError:
     def warn(msg, **kwargs):
-        # Issue a warning to stdout.
+        "Issue a warning to stdout."
         print("%s: %s" % ("Warning" if kwargs.get("cat") is None else kwargs["cat"].__name__, msg))
 
 import adafruit_bus_device.spi_device as spidev

--- a/adafruit_rfm9x.py
+++ b/adafruit_rfm9x.py
@@ -557,9 +557,10 @@ class RFM9x:
         listed in RFM9x.bw_bins."""
         bw_id = (self._read_u8(_RH_RF95_REG_1D_MODEM_CONFIG1) & 0xf0) >> 4
         if bw_id >= len(self.bw_bins):
-            return 500000
+            current_bandwidth = 500000
         else:
-            return self.bw_bins[bw_id]
+            current_bandwidth = self.bw_bins[bw_id]
+        return current_bandwidth
 
     @signal_bandwidth.setter
     def signal_bandwidth(self, val):

--- a/adafruit_rfm9x.py
+++ b/adafruit_rfm9x.py
@@ -417,10 +417,15 @@ class RFM9x:
         )
         # Optionally enable CRC checking on incoming packets.
         if enable_crc:
-            config = self._read_u8(_RH_RF95_REG_1E_MODEM_CONFIG2) | 0x04
+            self._write_u8(
+                _RH_RF95_REG_1E_MODEM_CONFIG2,
+                self._read_u8(_RH_RF95_REG_1E_MODEM_CONFIG2) | 0x04
+            )
         else:
-            config = self._read_u8(_RH_RF95_REG_1E_MODEM_CONFIG2) & 0xfb
-        self._write_u8(_RH_RF95_REG_1E_MODEM_CONFIG2, config)
+            self._write_u8(
+                _RH_RF95_REG_1E_MODEM_CONFIG2,
+                self._read_u8(_RH_RF95_REG_1E_MODEM_CONFIG2) & 0xfb
+            )
         self.enable_crc = enable_crc
         # Note no sync word is set for LoRa mode either!
         self._write_u8(_RH_RF95_REG_26_MODEM_CONFIG3, 0x00)  # Preamble lsb?

--- a/adafruit_rfm9x.py
+++ b/adafruit_rfm9x.py
@@ -374,7 +374,7 @@ class RFM9x:
         # Set signal bandwidth (set to 125000 to match RadioHead Bw125).
         bins = (7800, 10400, 15600, 20800, 31250, 41700, 62500, 125000, 250000)
         for bw, cutoff in enumerate(bins):
-            if bandwidth <= cutoff:
+            if signal_bandwidth <= cutoff:
                 break
         else:
             bw = 9

--- a/adafruit_rfm9x.py
+++ b/adafruit_rfm9x.py
@@ -337,7 +337,7 @@ class RFM9x:
 
     def __init__(self, spi, cs, reset, frequency, *, preamble_length=8,
                  high_power=True, baudrate=5000000, signal_bandwidth=125000,
-                 coding_rate=5, spreading_factor=7):
+                 coding_rate=5, spreading_factor=7, enable_crc=False):
         self.high_power = high_power
         # Device support SPI mode 0 (polarity & phase = 0) up to a max of 10mhz.
         # Set Default Baudrate to 5MHz to avoid problems
@@ -400,6 +400,10 @@ class RFM9x:
                 ((sf << 4) & 0xf0)
             )
         )
+        # Optionally enable CRC checking on incoming packets.
+        if enable_crc:
+            config = self._read_u8(_RH_RF95_REG_1E_MODEM_CONFIG2) | 0x04
+            self._write_u8(_RH_RF95_REG_1E_MODEM_CONFIG2, config)
         # Note no sync word is set for LoRa mode either!
         self._write_u8(_RH_RF95_REG_26_MODEM_CONFIG3, 0x00)  # Preamble lsb?
         # Set preamble length (default 8 bytes to match radiohead).

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.7',
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
This patch proposes the following enhancements without breaking existing user code or any default behaviors:
* Add to `RFM9x.__init__` a keyword input parameter, `signal_bandwidth`
* Add to `RFM9x.__init__` a keyword input parameter, `coding_rate`
* Add to `RFM9x.__init__` a keyword input parameter, `spreading_factor`
* Add to `RFM9x.__init__` a keyword input parameter, `enable_crc`
The defaults remain a match for RadioHead Bw125Cr45Sf128 mode with CRC checking off.

This patch has been used successfully with Adafruit RFM95W.  It has also successfully enabled communications between the Adafruit RFM95W and the TTGO LORA32 (an ESP32 board with a different RFM95 radio) at a variety of different settings, having verified that it really was communicating at those different bandwidths, etc.

This code was made possible through careful study of the code used in https://github.com/MZachmann/LightLora_Arduino to expose these same features.  Credit goes to Mark Zachmann for having done the truly hard work of figuring out exactly how to tickle the registers in the hardware.

The adafruit/Adafruit_CircuitPython_RFM9x library is an excellent library and it feels intuitive when using it.  Thank you for creating it and sharing it with others.  I hope these enhancements can expand its reach.

This suggested patch was mentioned in issue GH-20.

Notably, this patch includes changes made in another pull request (GH-19).