### PR TITLE
Fix GitHub repository URL to the correct value.

### DIFF
--- a/adafruit_rfm9x.py
+++ b/adafruit_rfm9x.py
@@ -44,7 +44,7 @@ import adafruit_bus_device.spi_device as spidev
 
 
 __version__ = "0.0.0-auto.0"
-__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_rfm95.git"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_RFM9x.git"
 
 
 # pylint: disable=bad-whitespace


### PR DESCRIPTION
What the title says... This change is needed so the upcoming `circup` utility can work correctly with this module (see: https://semver.org/).

Any questions? Just ask! :-) 

Thank you..!

cc/@ladyada