### PR TITLE
enable usage of interrupts with received packets

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -156,7 +156,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=board
+ignored-modules=board,RPi.GPIO
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.

--- a/adafruit_rfm9x.py
+++ b/adafruit_rfm9x.py
@@ -655,11 +655,13 @@ class RFM9x:
            The tx_header defaults to using the Broadcast addresses. It may be overidden
            by specifying a 4-tuple of bytes containing (To,From,ID,Flags)
            The timeout is just to prevent a hang (arbitrarily set to 2 seconds)
+           The keep_listening argument should be set to True if you want to start listening
+           automatically after the packet is sent. The default setting is False.
         """
         # Disable pylint warning to not use length as a check for zero.
         # This is a puzzling warning as the below code is clearly the most
         # efficient and proper way to ensure a precondition that the provided
-        # buffer be within an expected range of bounds.  Disable this check.
+        # buffer be within an expected range of bounds. Disable this check.
         # pylint: disable=len-as-condition
         assert 0 < len(data) <= 252
         assert len(tx_header) == 4, "tx header must be 4-tuple (To,From,ID,Flags)"
@@ -703,7 +705,7 @@ class RFM9x:
         """Wait to receive a packet from the receiver. Will wait for up to timeout_s amount of
            seconds for a packet to be received and decoded. If a packet is found the payload bytes
            are returned, otherwise None is returned (which indicates the timeout elapsed with no
-           reception).  If timeout is None it isnot used ( for use with interrupts)
+           reception).  If timeout is None it is not used ( for use with interrupts)
            If keep_listening is True (the default) the chip will immediately enter listening mode
            after reception of a packet, otherwise it will fall back to idle mode and ignore any
            future reception.

--- a/examples/rfm9x_rpi_interrupt.py
+++ b/examples/rfm9x_rpi_interrupt.py
@@ -1,0 +1,73 @@
+# Simple demo of sending and recieving data with the RFM95 LoRa radio.
+# Author: Tony DiCola
+import time
+import board
+import busio
+import digitalio
+import RPi.GPIO as io
+import adafruit_rfm9x
+
+
+# setup interrupt callback function
+def rfm9x_callback(rfm9x_irq):
+    global packet_received  #pylint: disable=global-statement
+    print("IRQ detected ",rfm9x_irq, rfm9x.rx_done)
+    # check to see if this was a rx interrupt - ignore tx
+    if rfm9x.rx_done:
+        packet = rfm9x.receive(timeout = None)
+        if packet is not None:
+            packet_received = True
+            # Received a packet!
+            # Print out the raw bytes of the packet:
+            print('Received (raw bytes): {0}'.format(packet))
+            print([hex(x) for x in packet])
+            print('RSSI: {0}'.format(rfm9x.rssi))
+
+
+# Define radio parameters.
+RADIO_FREQ_MHZ = 915.0  # Frequency of the radio in Mhz. Must match your
+                        # module! Can be a value like 915.0, 433.0, etc.
+
+# Define pins connected to the chip, use these if wiring up the breakout according to the guide:
+CS = digitalio.DigitalInOut(board.CE1)
+RESET = digitalio.DigitalInOut(board.D25)
+
+# Initialize SPI bus.
+spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
+
+# Initialze RFM radio
+rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ)
+
+# Note that the radio is configured in LoRa mode so you can't control sync
+# word, encryption, frequency deviation, or other settings!
+
+# You can however adjust the transmit power (in dB).  The default is 13 dB but
+# high power radios like the RFM95 can go up to 23 dB:
+rfm9x.tx_power = 23
+
+# configure the interrupt pin and event handling.
+RFM9X_G0 = 22
+io.setmode(io.BCM)
+io.setup(RFM9X_G0, io.IN,pull_up_down=io.PUD_DOWN)         # activate input
+io.add_event_detect(RFM9X_G0,io.RISING)
+io.add_event_callback(RFM9X_G0,rfm9x_callback)
+
+packet_received = False
+# Send a packet.  Note you can only send a packet up to 252 bytes in length.
+# This is a limitation of the radio packet size, so if you need to send larger
+# amounts of data you will need to break it into smaller send calls.  Each send
+# call will wait for the previous one to finish before continuing.
+rfm9x.send(bytes("Hello world!\r\n","utf-8"), keep_listening = True)
+print('Sent Hello World message!')
+
+# Wait to receive packets.  Note that this library can't receive data at a fast
+# rate, in fact it can only receive and process one 252 byte packet at a time.
+# This means you should only use this for low bandwidth scenarios, like sending
+# and receiving a single message at a time.
+print('Waiting for packets...')
+while True:
+    time.sleep(.1)
+    if packet_received:
+        rfm9x.send(bytes("back at you\r\n","utf-8"), keep_listening = True)
+        print('received message!')
+        packet_received = False

--- a/examples/rfm9x_rpi_interrupt.py
+++ b/examples/rfm9x_rpi_interrupt.py
@@ -68,6 +68,5 @@ print('Waiting for packets...')
 while True:
     time.sleep(.1)
     if packet_received:
-        rfm9x.send(bytes("back at you\r\n","utf-8"), keep_listening = True)
         print('received message!')
         packet_received = False

--- a/examples/rfm9x_rpi_interrupt.py
+++ b/examples/rfm9x_rpi_interrupt.py
@@ -1,5 +1,8 @@
-# Simple demo of sending and recieving data with the RFM95 LoRa radio.
-# Author: Tony DiCola
+# Example using Interrupts to send a message and then wait indefinitely for messages
+# to be received. Interrupts are used only for receive. sending is done with polling.
+# This example is for systems that support interrupts like the Raspberry Pi with "blinka"
+# CircuitPython does not support interrupts so it will not work on  Circutpython boards
+# Author: Tony DiCola, Jerry Needell
 import time
 import board
 import busio

--- a/examples/rfm9x_transmit.py
+++ b/examples/rfm9x_transmit.py
@@ -1,0 +1,59 @@
+# Example to send a packet periodically
+# Author: Jerry Needell
+#
+import time
+import board
+import busio
+import digitalio
+import adafruit_rfm9x
+
+transmit_interval=10
+
+# Define radio parameters.
+RADIO_FREQ_MHZ   = 915.0  # Frequency of the radio in Mhz. Must match your
+                          # module! Can be a value like 915.0, 433.0, etc.
+
+# Define pins connected to the chip.
+CS    = digitalio.DigitalInOut(board.CE1)
+RESET = digitalio.DigitalInOut(board.D25)
+
+# Initialize SPI bus.
+spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
+
+# Initialze RFM radio
+rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ)
+
+# Note that the radio is configured in LoRa mode so you can't control sync
+# word, encryption, frequency deviation, or other settings!
+
+# You can however adjust the transmit power (in dB).  The default is 13 dB but
+# high power radios like the RFM95 can go up to 23 dB:
+rfm9x.tx_power = 23
+
+
+# initialize counter
+counter = 0
+#send a broadcast mesage
+rfm9x.send(bytes("message number {}".format(counter),"UTF-8"))
+
+# Wait to receive packets.
+print('Waiting for packets...')
+#initialize flag and timer
+send_reading=False
+time_now=time.monotonic()
+while True:
+    # Look for a new packet - wait up to 5 seconds:
+    packet = rfm9x.receive(timeout=5.0)
+    # If no packet was received during the timeout then None is returned.
+    if packet is not None:
+        # Received a packet!
+        # Print out the raw bytes of the packet:
+        print('Received (raw bytes): {0}'.format(packet))
+        # send reading after any packet received
+    if time.monotonic()-time_now>transmit_interval:
+        #reset timeer
+        time_now=time.monotonic()
+        #clear flag to send data
+        send_reading=False
+        counter = counter + 1
+        rfm9x.send(bytes("message number {}".format(counter),"UTF-8"))

--- a/examples/rfm9x_transmit.py
+++ b/examples/rfm9x_transmit.py
@@ -7,6 +7,7 @@ import busio
 import digitalio
 import adafruit_rfm9x
 
+# set the time interval (seconds) for sending packets
 transmit_interval=10
 
 # Define radio parameters.


### PR DESCRIPTION
Change send/receive functions to allow for the use of interrupts in the user code.
the changes are invoked if receive is called with timeout=None
in this case the initial call to listen is skipped assuming a packet has already been received
the user code must call listen.
send was modified to accept a kwarg keep_listenting -- if set to True then listen is call after the packet is sent.

add example for interrupt usage for Raspberry Pi
add example that transmits periodically.

Tested on Raspberry Pi Zero-W
and on feather_m0_adalogger (tested transmit example and that existing code still runs)

These changes should not impact any existing code.