### PR TITLE
Enable CRC by default

### DIFF
--- a/adafruit_rfm9x.py
+++ b/adafruit_rfm9x.py
@@ -127,7 +127,7 @@ class RFM9x:
     - baudrate: Baud rate of the SPI connection, default is 10mhz but you might
     choose to lower to 1mhz if using long wires or a breadboard.
     - agc: Boolean to Enable/Disable Automatic Gain Control - Default=False (AGC off)
-    - agc: Boolean to Enable/Disable Cyclic Redundancy Check - Default=True (CRC Enabled)
+    - crc: Boolean to Enable/Disable Cyclic Redundancy Check - Default=True (CRC Enabled)
     Remember this library makes a best effort at receiving packets with pure
     Python code.  Trying to receive packets too quickly will result in lost data
     so limit yourself to simple scenarios of sending and receiving single

--- a/adafruit_rfm9x.py
+++ b/adafruit_rfm9x.py
@@ -277,8 +277,8 @@ class RFM9x:
         self.spreading_factor = 7
         # Default to enable CRC checking on incoming packets.
         self.enable_crc = crc
-        # set AGC - Default = False
         """CRC Enable state"""
+        # set AGC - Default = False
         self.auto_agc = agc
         """Automatic Gain Control state"""
         # Set transmit power to 13 dBm, a safe value any module supports.

--- a/adafruit_rfm9x.py
+++ b/adafruit_rfm9x.py
@@ -127,6 +127,7 @@ class RFM9x:
     - baudrate: Baud rate of the SPI connection, default is 10mhz but you might
     choose to lower to 1mhz if using long wires or a breadboard.
     - agc: Boolean to Enable/Disable Automatic Gain Control - Default=False (AGC off)
+    - agc: Boolean to Enable/Disable Cyclic Redundancy Check - Default=True (CRC Enabled)
     Remember this library makes a best effort at receiving packets with pure
     Python code.  Trying to receive packets too quickly will result in lost data
     so limit yourself to simple scenarios of sending and receiving single
@@ -230,7 +231,8 @@ class RFM9x:
         preamble_length=8,
         high_power=True,
         baudrate=5000000,
-        agc=False
+        agc=False,
+        crc=True
     ):
         self.high_power = high_power
         # Device support SPI mode 0 (polarity & phase = 0) up to a max of 10mhz.
@@ -273,9 +275,10 @@ class RFM9x:
         self.signal_bandwidth = 125000
         self.coding_rate = 5
         self.spreading_factor = 7
-        # Default to disable CRC checking on incoming packets.
-        self.enable_crc = False
-        # set AGC - Default = True
+        # Default to enable CRC checking on incoming packets.
+        self.enable_crc = crc
+        # set AGC - Default = False
+        """CRC Enable state"""
         self.auto_agc = agc
         """Automatic Gain Control state"""
         # Set transmit power to 13 dBm, a safe value any module supports.

--- a/examples/rfm9x_node1.py
+++ b/examples/rfm9x_node1.py
@@ -27,8 +27,6 @@ spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 # Initialze RFM radio
 rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ)
 
-# enable CRC checking
-rfm9x.enable_crc = True
 # set node addresses
 rfm9x.node = 1
 rfm9x.destination = 2

--- a/examples/rfm9x_node1_ack.py
+++ b/examples/rfm9x_node1_ack.py
@@ -27,8 +27,6 @@ spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 # Initialze RFM radio
 rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ)
 
-# enable CRC checking
-rfm9x.enable_crc = True
 # set delay before sending ACK
 rfm9x.ack_delay = 0.1
 # set node addresses

--- a/examples/rfm9x_node1_bonnet.py
+++ b/examples/rfm9x_node1_bonnet.py
@@ -66,9 +66,6 @@ except RuntimeError:
 
 display.show()
 
-# enable CRC checking
-rfm9x.enable_crc = True
-
 # set node addresses
 rfm9x.node = 1
 rfm9x.destination = 2

--- a/examples/rfm9x_node2.py
+++ b/examples/rfm9x_node2.py
@@ -24,8 +24,6 @@ spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 # Initialze RFM radio
 rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ)
 
-# enable CRC checking
-rfm9x.enable_crc = True
 # set node addresses
 rfm9x.node = 2
 rfm9x.destination = 1

--- a/examples/rfm9x_node2_ack.py
+++ b/examples/rfm9x_node2_ack.py
@@ -24,8 +24,6 @@ spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 # Initialze RFM radio
 rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ)
 
-# enable CRC checking
-rfm9x.enable_crc = True
 # set delay before transmitting ACK (seconds)
 rfm9x.ack_delay = 0.1
 # set node addresses


### PR DESCRIPTION
implements issue #62 enable CRC by default for compatibility with Arduino (RadioHead) 
This will have minimal impact on existing CircuitPython to CircuitPython communication because the CircuitPython library allows the "explicit" header setting to determine if the CRC is used. The radio uses an additional header to determine if the CRC is present.  The RadioHead library has an extra check to verify that the transmitter and received have matching CRC state.  In Circuit Python, even if one side has the CRC enabled and the other does not, the packets will be received. The internal header determines if the CRC is present. Exiting deployments that do not have the CRC enabled will still work as before. 

Tested between a Raspberry Pi and umfeathers2 (CP to CP) and between a Raspberry Pi and an Arduino Uno (CP to Radiohead) 

The changes to the examples were to remove the explicit enable of the CRC since it is done by default.
To disable the CRC either:
1)disable it when instantiating the device (add crc=False) to the kwarg list
2)chase the setting via the enable_crc property )eg. rfm9x.enable_crc=False)

I did not test each of the examples, the cages were the same in all examples modified.
