### PR TITLE
Allow __version__ population, fix problem matchers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,8 @@ jobs:
         pip install --force-reinstall Sphinx sphinx-rtd-theme pre-commit
     - name: Library version
       run: git describe --dirty --always --tags
+    - name: Setup problem matchers
+      uses: adafruit/circuitpython-action-library-ci-problem-matchers@v1
     - name: Pre-commit hooks
       run: |
         pre-commit run --all-files
@@ -68,7 +70,8 @@ jobs:
       if: contains(steps.need-pypi.outputs.pyproject-toml, 'pyproject.toml')
       run: |
         pip install --upgrade build twine
+        for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
+            sed -i -e "s/0.0.0-auto.0/1.2.3/" $file;
+        done;
         python -m build
         twine check dist/*
-    - name: Setup problem matchers
-      uses: adafruit/circuitpython-action-library-ci-problem-matchers@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,5 +81,8 @@ jobs:
         TWINE_USERNAME: ${{ secrets.pypi_username }}
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
       run: |
+        for file in $(find -not -path "./.*" -not -path "./docs*" \( -name "*.py" -o -name "*.toml" \) ); do
+            sed -i -e "s/0.0.0-auto.0/${{github.event.release.tag_name}}/" $file;
+        done;
         python -m build
         twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires = [
 [project]
 name = "adafruit-circuitpython-rfm9x"
 description = "CircuitPython library for RFM95/6/7/8 LoRa 433/915mhz radio modules."
+version = "0.0.0-auto.0"
 readme = "README.rst"
 authors = [
     {name = "Adafruit Industries", email = "circuitpython@adafruit.com"}
@@ -39,12 +40,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
 ]
-dynamic = ["version", "dependencies"]
+dynamic = ["dependencies"]
 
 [tool.setuptools]
 py-modules = ["adafruit_rfm9x"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
-
-[tool.setuptools_scm]


### PR DESCRIPTION
Populates `__version__` (assuming it's set to the expected `0.0.0-auto.0`) before building the package and during the release CI process.  Also tests the `sed` usage (though not sure how that might fail) during the build CI process.

Additionally move the problem matchers step before the pre-commit hooks so it works as intended.  Seems like a good time to do that.

For reference tested successfully in my CSV library:  https://github.com/tekktrik/CircuitPython_CSV

If this goes well, this file can just be copy/pasted like it is here during the move to `pyproject.toml`.